### PR TITLE
 Fix missing port argument

### DIFF
--- a/lib/redmine_git_mirror/url.rb
+++ b/lib/redmine_git_mirror/url.rb
@@ -194,6 +194,8 @@ module RedmineGitMirror
         end
 
         s << @host
+	s<<":"
+	s<< @port
         s << path
       elsif @host
         if @user

--- a/lib/redmine_git_mirror/url.rb
+++ b/lib/redmine_git_mirror/url.rb
@@ -194,8 +194,10 @@ module RedmineGitMirror
         end
 
         s << @host
-	s<<":"
-	s<< @port
+        if @port
+	          s<<":"
+	          s<< @port
+        end
         s << path
       elsif @host
         if @user


### PR DESCRIPTION
In our case, the GIT server use the HTTP protocol on port 3000
With this modification, we could use the url "http://git_host_name:3000/path/to/repo.get"
